### PR TITLE
deploy job should only run on main repo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'FFXI-Guides/FFXI-Guides.github.io'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,6 +51,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'FFXI-Guides/FFXI-Guides.github.io'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Based on description from [this documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions) we should be able to make sure it only runs on main repo + see if someone tries to change this in a PR